### PR TITLE
Update colophon.xhtml

### DIFF
--- a/src/epub/text/colophon.xhtml
+++ b/src/epub/text/colophon.xhtml
@@ -20,7 +20,7 @@
 			<a href="https://sniggle.net/TPL">David <abbr class="name">M.</abbr> Gross</a>,<br/>
 			and is based on a transcription produced in 2000 by<br/>
 			<a href="https://www.gutenberg.org/ebooks/2046">Project Gutenberg</a><br/>
-			and on digital scans available at the<br/>
+			and on digital scans available at<br/>
 			<a href="https://www.google.com/books/edition/Clotel_or_The_president_s_daughter/JLoBAAAAQAAJ">Google Books</a>.</p>
 			<p>The cover page is adapted from<br/>
 			<i epub:type="se:name.visual-art.painting">Isabella</i>,<br/>


### PR DESCRIPTION
removing "the" in "the Google Books"